### PR TITLE
Remove config folder mapping

### DIFF
--- a/code-server/rootfs/etc/s6-overlay/scripts/01-vs-user
+++ b/code-server/rootfs/etc/s6-overlay/scripts/01-vs-user
@@ -3,7 +3,7 @@
 # Home Assistant Add-on: Code Server
 # Persists user settings and installs custom user packages.
 # ==============================================================================
-readonly -a DIRECTORIES=(config addon_configs addons backup homeassistant media share ssl)
+readonly -a DIRECTORIES=(addon_configs addons backup homeassistant media share ssl)
 readonly GIT_USER_PATH=/data/git
 readonly SSH_USER_PATH=/data/.ssh
 readonly ZSH_HISTORY_FILE=/root/.zsh_history


### PR DESCRIPTION
# Proposed Changes

/config folder mapping is not needed as it can be accessed with /addon_configs/xxxx_code-server

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
